### PR TITLE
Fix typo in pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repo to test sending DataFrame via pyarrow
 Currently segfaults when trying to deserialize DataFrame
 
 ```
-pip install -r requirements
+pip install -r requirements.txt
 ```
 
 Sanic-based server in one window:


### PR DESCRIPTION
It's a bit OCD but I cannot let that mistake I introduced :-)